### PR TITLE
deactivate tinymce if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,8 @@ Zur Konfiguration eigener Profile bitte in das default Profil schauen und die [T
 
 ## Update von TinyMCE 5
 
-Bei der Installation können vorhandene Profile aus TinyMCE 5 migriert werden. Folgendes Vorgehen ist hierzu notwendig.
-
-1. *TinyMCE 5 nicht deinstallieren oder löschen!* TinyMCE5 darf nur deaktiviert werden, damit die Profile erhalten bleiben.
-
-2. TinyMCE installieren. Hierbei werden die vorhandenen Profile aus TinyMCE 5 nach TinyMCE kopiert.
-
-3. TinyMCE 5 deinstallieren und löschen.
+Bei der Installation werden vorhandene Profile aus TinyMCE 5 migriert. Nach der Migration wird TinyMCE5 deaktiviert. 
+Es empfiehlt sich die Funktionalität im neuen AddOn zu prüfen und erst im Anschluss TinyMCE5 zu löschhen. 
 
 Die Klasse `tiny5-editor` wird weiterhin unterstützt. Wir empfehlen aber nur noch die Klasse `tiny-editor` für die Feldidentifikation zu verwenden. Eine Textarea mit tinyMCE hat dann beispielsweise folgenden Code: `<textarea class="tiny-editor form-control" data-profile="full" name="REX_INPUT_VALUE[1]">REX_VALUE[1]</textarea>`
 

--- a/install.php
+++ b/install.php
@@ -11,7 +11,7 @@ $addon = rex_addon::get("tinymce");
 
 $new_table_name = rex::getTable('tinymce_profiles'); 
 
-if (rex_addon::get('tinymce5')->isAvailable() && !$addon->hasConfig('migrated')) {
+if (rex_addon::get('tinymce5')->isAvailable()) {
     $old_table_name = rex::getTable('tinymce5_profiles');
     
     // deactivate tiny5 addon

--- a/install.php
+++ b/install.php
@@ -15,8 +15,8 @@ if (rex_addon::get('tinymce5')->isAvailable()) {
     $old_table_name = rex::getTable('tinymce5_profiles');
     
     // deactivate tiny5 addon
-    $addon = rex_addon::get('tinymce5');
-    $package_manager = rex_package_manager::factory($addon);
+    $addon_old = rex_addon::get('tinymce5');
+    $package_manager = rex_package_manager::factory($addon_old );
     $package_manager->deactivate();
 
 

--- a/install.php
+++ b/install.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @author mail[at]doerr-softwaredevelopment[dot]com Joachim Doerr
  * @package redaxo5
@@ -7,16 +8,24 @@
 
 /** @var rex_addon $this */
 $addon = rex_addon::get("tinymce");
-$old_table_name = rex::getTable('tinymce5_profiles');
-$new_table_name = rex::getTable('tinymce_profiles');
+if (rex_addon::get('tinymce')->isAvailable() && !$addon->hasConfig('migrated')) {
+    $old_table_name = rex::getTable('tinymce5_profiles');
+    $new_table_name = rex::getTable('tinymce_profiles');
 
-// duplicate Table from tinymce5 to 6 if available
-$tiny5table = rex_sql::factory()->setQuery('SHOW TABLES LIKE "'.$old_table_name.'"' )->getRows();
-$tinytable = rex_sql::factory()->setQuery('SHOW TABLES LIKE "'.$new_table_name.'"' )->getRows();
-if ($tiny5table && !$tinytable) {
-    rex_sql::factory()->setQuery('CREATE TABLE '. $new_table_name .' LIKE '. $old_table_name);
-    rex_sql::factory()->setQuery('INSERT INTO `'.$new_table_name.'` SELECT * FROM `'.$old_table_name.'`');
-    $addon->setProperty('successmsg', '<br><strong>' . rex_i18n::msg("tinymce_migration_message") . '</strong>');
+    // deactivate tiny5 addon
+    $addon = rex_addon::get('tinymce5');
+    $package_manager = rex_package_manager::factory($addon);
+    $package_manager->deactivate();
+
+
+    // duplicate Table from tinymce5 to 6 if available
+    $tiny5table = rex_sql::factory()->setQuery('SHOW TABLES LIKE "' . $old_table_name . '"')->getRows();
+    $tinytable = rex_sql::factory()->setQuery('SHOW TABLES LIKE "' . $new_table_name . '"')->getRows();
+    if ($tiny5table && !$tinytable) {
+        rex_sql::factory()->setQuery('CREATE TABLE ' . $new_table_name . ' LIKE ' . $old_table_name);
+        rex_sql::factory()->setQuery('INSERT INTO `' . $new_table_name . '` SELECT * FROM `' . $old_table_name . '`');
+        $addon->setProperty('successmsg', '<br><strong>' . rex_i18n::msg("tinymce_migration_message") . '</strong>');
+    }
 }
 
 

--- a/install.php
+++ b/install.php
@@ -8,10 +8,12 @@
 
 /** @var rex_addon $this */
 $addon = rex_addon::get("tinymce");
-if (rex_addon::get('tinymce')->isAvailable() && !$addon->hasConfig('migrated')) {
-    $old_table_name = rex::getTable('tinymce5_profiles');
-    $new_table_name = rex::getTable('tinymce_profiles');
 
+$old_table_name = rex::getTable('tinymce5_profiles');
+
+if (rex_addon::get('tinymce')->isAvailable() && !$addon->hasConfig('migrated')) {
+    $new_table_name = rex::getTable('tinymce_profiles'); 
+    
     // deactivate tiny5 addon
     $addon = rex_addon::get('tinymce5');
     $package_manager = rex_package_manager::factory($addon);

--- a/install.php
+++ b/install.php
@@ -11,7 +11,7 @@ $addon = rex_addon::get("tinymce");
 
 $new_table_name = rex::getTable('tinymce_profiles'); 
 
-if (rex_addon::get('tinymce')->isAvailable() && !$addon->hasConfig('migrated')) {
+if (rex_addon::get('tinymce5')->isAvailable() && !$addon->hasConfig('migrated')) {
     $old_table_name = rex::getTable('tinymce5_profiles');
     
     // deactivate tiny5 addon

--- a/install.php
+++ b/install.php
@@ -9,10 +9,10 @@
 /** @var rex_addon $this */
 $addon = rex_addon::get("tinymce");
 
-$old_table_name = rex::getTable('tinymce5_profiles');
+$new_table_name = rex::getTable('tinymce_profiles'); 
 
 if (rex_addon::get('tinymce')->isAvailable() && !$addon->hasConfig('migrated')) {
-    $new_table_name = rex::getTable('tinymce_profiles'); 
+    $old_table_name = rex::getTable('tinymce5_profiles');
     
     // deactivate tiny5 addon
     $addon = rex_addon::get('tinymce5');

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -49,4 +49,4 @@ tinymce_upload_default = Image-Drag&Drop-Upload
 tinymce_upload_default_description = Bilder können via drag+drop in das Textfeld gesetzt werden
 
 #migration
-tinymce_migration_message = Die Profile des TinyMCE5-AddOns wurden migriert. Bitte die Readme beachten. 
+tinymce_migration_message = Die Profile des TinyMCE5-AddOns wurden migriert und TinyMCE5 deaktiviert. TinyMCE5 kann jetzt deinstalliert werden. Bitte die Readme beachten. 

--- a/package.yml
+++ b/package.yml
@@ -35,7 +35,6 @@ requires:
 conflicts:
     packages:
         tinymce4: '>=0.0.0'
-        tinymce5: '>=0.0.0'
 
 installer_ignore:
     - .github


### PR DESCRIPTION
TinyMCE5 wird automatisch deaktiviert. 
So ist sichergestellt dass auch wirklich genutzte Profile migriert werden. Also von einem genutzten Tiny5. 
Sonst würden Profile von einem deaktivierten Tiny übernommen werden, das garnicht im Einsatz ist. 

<img width="1012" alt="Bildschirm­foto 2023-04-13 um 21 39 13" src="https://user-images.githubusercontent.com/791247/231865840-88016d38-1b0b-488b-aa35-3c8224d7ecfb.png">
